### PR TITLE
Adds nested tab support.  This allows fields in nested tabs to be saved.

### DIFF
--- a/inc/cmb2-tabs.class.php
+++ b/inc/cmb2-tabs.class.php
@@ -35,8 +35,6 @@ class CMB2_Tabs {
 		$this->setting   = $field_object->args( 'tabs' );
 		$this->object_id = $object_id;
 
-		error_log('escaped value: ' . var_export( $escaped_value, true ) );
-
 		// Set layout
 		$layout       = empty( $this->setting['layout'] ) ? 'ui-tabs-horizontal' : "ui-tabs-{$this->setting['layout']}";
 		$default_data = version_compare( CMB2_VERSION, '2.2.2', '>=' ) ? array(
@@ -140,7 +138,7 @@ class CMB2_Tabs {
 	 * @param $post_id
 	 * @param $data
 	 */
-	public static function save( $override_value, $value, $post_id, $data, $levels = 5 ) {
+	public static function save( $override_value, $value, $post_id, $data ) {
 		foreach ( $data['tabs']['tabs'] as $tab ) {
 			$setting_fields = array_merge( $data['tabs']['config'], array( 'fields' => $tab['fields'] ) );
 			$CMB2           = new \CMB2( $setting_fields, $post_id );

--- a/inc/cmb2-tabs.class.php
+++ b/inc/cmb2-tabs.class.php
@@ -116,7 +116,7 @@ class CMB2_Tabs {
 					foreach ( $tab_field_tab['fields'] as $tab_field_tab_field ) {
 						$fields[] = $tab_field_tab_field;
 
-						$fields_in_nested_tabs = self::get_fields_from_nested_tabs( $tab_field );
+						$fields_in_nested_tabs = self::get_fields_from_nested_tabs( $tab_field_tab_field );
 
 						foreach ( $fields_in_nested_tabs as $field_in_nested_tabs ) {
 							$fields[] = $field_in_nested_tabs;


### PR DESCRIPTION
This pull request adds support for nested tabs.  Fields in nested tabs can now be saved.  Previously, the save method never looked inside a child tab field.  The code I added recursively searches nested tabs (currently unlimited levels), and saves the fields inside.